### PR TITLE
Bump react version

### DIFF
--- a/package.js
+++ b/package.js
@@ -20,7 +20,7 @@ Npm.depends({
 });
 
 Package.onUse(function(api){
-    api.use(['react@0.1.3'], 'client');
+    api.use(['react@0.1.9'], 'client');
     api.use(['cosmos:browserify@0.5.0'], 'client');
 
     api.addFiles([


### PR DESCRIPTION
While using `react` on `.meteor/packages`:

```
=> Errors prevented startup:

   While determining active plugins:
   error: conflict: two packages included in pageme:core (jsx and tomesch:react-jsx) are both trying to handle *.jsx
```

Upgrading package to latest react version solves this.
